### PR TITLE
Fix links, remove EOL, and change version to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,16 @@
-| :warning: On September 1, 2021, Adobe will end support for Brackets. If you would like to continue using, maintaining, and improving Brackets, you may fork the project on [GitHub](https://github.com/adobe/brackets). Through Adobe’s partnership with Microsoft, we encourage users to migrate to [Visual Studio Code](https://aka.ms/brackets-to-vscode), Microsoft’s free code editor built on open source.
-| ---
-
 ## Overview
 
-This is the CEF3-based application shell for [Brackets](https://github.com/adobe/brackets). 
+This is the CEF3-based application shell for [Brackets](https://github.com/brackets-cont/brackets). 
 
-Please read the main [README in the brackets repo](https://github.com/adobe/brackets/blob/master/README.md) 
+Please read the main [README in the brackets repo](https://github.com/brackets-cont/brackets/blob/master/README.md) 
 for general information about Brackets.
 
 If you are interested in contributing to this shell, let us know on the 
-[brackets-dev Google Group](http://groups.google.com/group/brackets-dev), 
-or on the [#brackets channel on freenode](http://webchat.freenode.net/?channels=brackets).
+[Brackets Discord Server](https://discord.gg/rBpTBPttca), 
+or on the [Brackets Continued Matrix Space](https://matrix.to/#/#brackets-continued:scanuproductions.com).
 
 If you run into any issues with this new shell, please file a bug in the 
-[brackets issue tracker](https://github.com/adobe/brackets/issues).
+[brackets issue tracker](https://github.com/brackets-cont/brackets/issues).
 
 _Note: The brackets-shell is only maintained for use by the Brackets project. Although some people have 
 definitely had success using it as an app shell for other projects, we don't provide any official 
@@ -23,7 +20,7 @@ will likely find it easier to use a project like [NW.js](https://github.com/nwjs
 ## Running
 
 There are no downloads for the brackets-shell. You either need to 
-build from source, or grab the [latest Brackets installer](http://download.brackets.io) 
+build from source, or grab the [latest Brackets installer](http://brackets.io) 
 and run the shell from that.
 
 When the app is launched, it first looks for an index.html file in the following locations:
@@ -38,4 +35,4 @@ The preferences are stored in `{USER}/Library/Application Support/Brackets/cef_d
 
 ## Building
 
-Information on building the app shell can be found on the [brackets-shell wiki](https://github.com/adobe/brackets-shell/wiki/Building-brackets-shell).
+Information on building the app shell can be found on the [brackets-shell wiki](https://github.com/brackets-cont/brackets-shell/wiki/Building-brackets-shell).

--- a/appshell/client_app.cpp
+++ b/appshell/client_app.cpp
@@ -75,7 +75,7 @@ void ClientApp::OnContextReleased(CefRefPtr<CefBrowser> browser,
   for (; it != render_delegates_.end(); ++it)
     (*it)->OnContextReleased(this, browser, frame, context);
  
-  // This is to fix the crash on quit(https://github.com/adobe/brackets/issues/7683) 
+  // This is to fix the crash on quit(https://github.com/brackets-cont/brackets/issues/7683) 
   // after integrating CEF 2171.
 
   // On Destruction, callback_map_ was getting destroyed

--- a/appshell/client_handler.cpp
+++ b/appshell/client_handler.cpp
@@ -437,7 +437,7 @@ void ClientHandler::SendOpenFileCommand(CefRefPtr<CefBrowser> browser, const Cef
   std::string cmd = "require('command/CommandManager').execute('file.openDroppedFiles'," + fileArrayStr + ")";
 
   // if files are droppend and the Open Dialog is visible, then browser is NULL
-  // This fixes https://github.com/adobe/brackets/issues/7752
+  // This fixes https://github.com/brackets-cont/brackets/issues/7752
   if (browser) {
     browser->GetMainFrame()->ExecuteJavaScript(CefString(cmd.c_str()),
                                 browser->GetMainFrame()->GetURL(), 0);

--- a/appshell/mac/Info.plist
+++ b/appshell/mac/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.15.0</string>
+	<string>2.0.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.15.0</string>
+	<string>2.0.0</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/appshell/version.rc
+++ b/appshell/version.rc
@@ -31,7 +31,7 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 //
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION    	1,15,0,0
+FILEVERSION    	2,0,0,0
 /* PRODUCTVERSION 	1,0,0,0 */
 FILEOS         	VOS__WINDOWS32
 FILETYPE       	VFT_APP
@@ -42,7 +42,7 @@ BEGIN
         BEGIN
             VALUE "CompanyName",      "brackets.io\0"
             VALUE "FileDescription",  "\0"
-            VALUE "FileVersion",      "Release 1.15.0\0"
+            VALUE "FileVersion",      "Release 2.0.0\0"
             VALUE "ProductName",      APP_NAME "\0"
             VALUE "ProductVersion",   "\0"
             VALUE "LegalCopyright",   "(c) 2012 Adobe Systems, Inc.\0"

--- a/appshell/version_linux.h
+++ b/appshell/version_linux.h
@@ -1,1 +1,1 @@
-#define APP_VERSION "1.15.0.0"
+#define APP_VERSION "2.0.0.0"

--- a/installer/mac/buildInstaller.sh
+++ b/installer/mac/buildInstaller.sh
@@ -2,7 +2,7 @@
 
 # config
 releaseName="Brackets"
-version="1.15"
+version="2.0"
 dmgName="${releaseName} Release ${version}"
 format="bzip2"
 encryption="none"

--- a/installer/win/Brackets_en-us.wxl
+++ b/installer/win/Brackets_en-us.wxl
@@ -11,7 +11,7 @@
     You must not remove this notice, or any other, from this software.
 -->
 <!--
-    Modified from Wix 3.5 for Brackets. See https://github.com/adobe/brackets-shell/
+    Modified from Wix 3.5 for Brackets. See https://github.com/brackets-cont/brackets-shell/
 -->
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
     <String Id="LicenseRtf" Overridable="yes">EULA_en-us.rtf</String>   

--- a/installer/win/Brackets_fr-fr.wxl
+++ b/installer/win/Brackets_fr-fr.wxl
@@ -11,7 +11,7 @@
     You must not remove this notice, or any other, from this software.
 -->
 <!--
-    Modified from Wix 3.5 for Brackets. See https://github.com/adobe/brackets-shell/
+    Modified from Wix 3.5 for Brackets. See https://github.com/brackets-cont/brackets-shell/
 -->
 <WixLocalization Culture="fr-fr" xmlns="http://schemas.microsoft.com/wix/2006/localization">
     <String Id="LicenseRtf" Overridable="yes">EULA_fr-fr.rtf</String>

--- a/installer/win/ExitDialog.wxs
+++ b/installer/win/ExitDialog.wxs
@@ -11,7 +11,7 @@
     You must not remove this notice, or any other, from this software.
 -->
 <!--
-    Modified from Wix 3.5 for Brackets. See https://github.com/adobe/brackets-shell/
+    Modified from Wix 3.5 for Brackets. See https://github.com/brackets-cont/brackets-shell/
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Fragment>

--- a/installer/win/InstallDirDlg.wxs
+++ b/installer/win/InstallDirDlg.wxs
@@ -11,7 +11,7 @@
     You must not remove this notice, or any other, from this software.
 -->
 <!--
-    Modified from Wix 3.5 for Brackets. See https://github.com/adobe/brackets-shell/
+    Modified from Wix 3.5 for Brackets. See https://github.com/brackets-cont/brackets-shell/
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Fragment>

--- a/installer/win/LicenseAgreementDlg.wxs
+++ b/installer/win/LicenseAgreementDlg.wxs
@@ -11,7 +11,7 @@
     You must not remove this notice, or any other, from this software.
 -->
 <!--
-    Modified from Wix 3.5 for Brackets. See https://github.com/adobe/brackets-shell/
+    Modified from Wix 3.5 for Brackets. See https://github.com/brackets-cont/brackets-shell/
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Fragment>

--- a/installer/win/MaintenanceWelcomeDlg.wxs
+++ b/installer/win/MaintenanceWelcomeDlg.wxs
@@ -11,7 +11,7 @@
     You must not remove this notice, or any other, from this software.
 -->
 <!--
-    Modified from Wix 3.5 for Brackets. See https://github.com/adobe/brackets-shell/
+    Modified from Wix 3.5 for Brackets. See https://github.com/brackets-cont/brackets-shell/
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Fragment>

--- a/installer/win/MaintenanceWelcomeDlg_src.wxs
+++ b/installer/win/MaintenanceWelcomeDlg_src.wxs
@@ -11,7 +11,7 @@
     You must not remove this notice, or any other, from this software.
 -->
 <!--
-    Modified from Wix 3.5 (MaintenanceWelcomeDlg.wxs) for Brackets. See https://github.com/adobe/brackets-shell/
+    Modified from Wix 3.5 (MaintenanceWelcomeDlg.wxs) for Brackets. See https://github.com/brackets-cont/brackets-shell/
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Fragment>

--- a/installer/win/PrepareDlg.wxs
+++ b/installer/win/PrepareDlg.wxs
@@ -11,7 +11,7 @@
     You must not remove this notice, or any other, from this software.
 -->
 <!--
-    Modified from Wix 3.5 for Brackets. See https://github.com/adobe/brackets-shell/
+    Modified from Wix 3.5 for Brackets. See https://github.com/brackets-cont/brackets-shell/
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Fragment>

--- a/installer/win/ProgressDlg.wxs
+++ b/installer/win/ProgressDlg.wxs
@@ -11,7 +11,7 @@
     You must not remove this notice, or any other, from this software.
 -->
 <!--
-    Modified from Wix 3.5 for Brackets. See https://github.com/adobe/brackets-shell/
+    Modified from Wix 3.5 for Brackets. See https://github.com/brackets-cont/brackets-shell/
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Fragment>

--- a/installer/win/README.MD
+++ b/installer/win/README.MD
@@ -29,7 +29,7 @@ Normally, the installer scripts are run via Jenkins on our build machine. These 
 9. You may need to locally edit `wix.base` in brackets-win-install-build.xml if the Wix install folder doesn't match what's hardcoded there
 
 ## Update Release Number with Grunt
-To rev the Brackets release number with Grunt, both brackets-shell and brackets repositories must be updated. For the initial Grunt setup, see: https://github.com/adobe/brackets/wiki/Grunt-Setup.
+To rev the Brackets release number with Grunt, both brackets-shell and brackets repositories must be updated. For the initial Grunt setup, see: https://github.com/brackets-cont/brackets/wiki/Grunt-Setup.
 
 brackets       > grunt set-release --release=NN
 brackets-shell > grunt set-release --release=NN

--- a/installer/win/ResumeDlg.wxs
+++ b/installer/win/ResumeDlg.wxs
@@ -11,7 +11,7 @@
     You must not remove this notice, or any other, from this software.
 -->
 <!--
-    Modified from Wix 3.5 for Brackets. See https://github.com/adobe/brackets-shell/
+    Modified from Wix 3.5 for Brackets. See https://github.com/brackets-cont/brackets-shell/
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Fragment>

--- a/installer/win/UserExit.wxs
+++ b/installer/win/UserExit.wxs
@@ -11,7 +11,7 @@
     You must not remove this notice, or any other, from this software.
 -->
 <!--
-    Modified from Wix 3.5 for Brackets. See https://github.com/adobe/brackets-shell/
+    Modified from Wix 3.5 for Brackets. See https://github.com/brackets-cont/brackets-shell/
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Fragment>

--- a/installer/win/VerifyReadyDlg.wxs
+++ b/installer/win/VerifyReadyDlg.wxs
@@ -11,7 +11,7 @@
     You must not remove this notice, or any other, from this software.
 -->
 <!--
-    Modified from Wix 3.5 for Brackets. See https://github.com/adobe/brackets-shell/
+    Modified from Wix 3.5 for Brackets. See https://github.com/brackets-cont/brackets-shell/
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Fragment>

--- a/installer/win/WelcomeDlg.wxs
+++ b/installer/win/WelcomeDlg.wxs
@@ -11,7 +11,7 @@
     You must not remove this notice, or any other, from this software.
 -->
 <!--
-    Modified from Wix 3.5 for Brackets. See https://github.com/adobe/brackets-shell/
+    Modified from Wix 3.5 for Brackets. See https://github.com/brackets-cont/brackets-shell/
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Fragment>

--- a/installer/win/WelcomeEulaDlg.wxs
+++ b/installer/win/WelcomeEulaDlg.wxs
@@ -11,7 +11,7 @@
     You must not remove this notice, or any other, from this software.
 -->
 <!--
-    Modified from Wix 3.5 for Brackets. See https://github.com/adobe/brackets-shell/
+    Modified from Wix 3.5 for Brackets. See https://github.com/brackets-cont/brackets-shell/
 -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Fragment>

--- a/installer/win/WixUI_InstallDir.wxs
+++ b/installer/win/WixUI_InstallDir.wxs
@@ -20,7 +20,7 @@ First-time install dialog sequence:      Maintenance dialog sequence:
    - WixUI_DiskCostDlg
 -->
 <!--
-    Modified from Wix 3.5 for Brackets. See https://github.com/adobe/brackets-shell/
+    Modified from Wix 3.5 for Brackets. See https://github.com/brackets-cont/brackets-shell/
 -->
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">

--- a/installer/win/WixUI_en-us.wxl
+++ b/installer/win/WixUI_en-us.wxl
@@ -11,7 +11,7 @@
     You must not remove this notice, or any other, from this software.
 -->
 <!--
-    Modified from Wix 3.5 for Brackets. See https://github.com/adobe/brackets-shell/
+    Modified from Wix 3.5 for Brackets. See https://github.com/brackets-cont/brackets-shell/
 -->
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
     <String Id="WixUIBack" Overridable="yes"><!-- _locID_text="WixUIBack" _locComment="WixUIBack" -->&amp;Back</String>

--- a/installer/win/brackets-win-install-build.xml
+++ b/installer/win/brackets-win-install-build.xml
@@ -11,8 +11,8 @@ default="build.mul">
   <!-- Product & version labeling -->
   <!-- See also: product name definitions in Brackets_<locale>.wxl -->
   <property name="product.shortname" value="Brackets"/>
-  <property name="product.release.number.major" value="1"/>
-  <property name="product.release.number.minor" value="15"/>
+  <property name="product.release.number.major" value="2"/>
+  <property name="product.release.number.minor" value="0"/>
   <property name="product.release.number.build" value="0"/>
   <property name="product.version.number" value="${product.release.number.major}.${product.release.number.minor}.${product.release.number.build}"/>
   <property name="product.version.name" value="Release ${product.release.number.major}.${product.release.number.minor}"/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "Brackets-Shell",
-    "version": "1.15.0-0",
+    "version": "2.0.0-0",
     "homepage": "http://brackets.io",
     "issues": {
         "url": "http://github.com/brackets-cont/brackets-shell/issues"

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
     "version": "1.15.0-0",
     "homepage": "http://brackets.io",
     "issues": {
-        "url": "http://github.com/adobe/brackets-shell/issues"
+        "url": "http://github.com/brackets-cont/brackets-shell/issues"
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/adobe/brackets-shell.git",
+        "url": "https://github.com/brackets-cont/brackets-shell.git",
         "branch": "",
         "SHA": ""
     },


### PR DESCRIPTION
Changed all links from adobe/brackets and adobe/brackets-shell to brackets-cont/brackets and brackets-cont/brackets-shell in readme.md and other files. Removed EOL warning from readme.md. Changed the version number to 2.0.0. The version number changed has been discussed in #28 in the brackets-cont/brackets repo.