### PR TITLE
Brackets is under active development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-| :warning: On September 1, 2021, Adobe will end support for Brackets. If you would like to continue using, maintaining, and improving Brackets, you may fork the project on [GitHub](https://github.com/adobe/brackets). Through Adobe’s partnership with Microsoft, we encourage users to migrate to [Visual Studio Code](https://aka.ms/brackets-to-vscode), Microsoft’s free code editor built on open source.
-| ---
-
 ## Overview
 
 This is the CEF3-based application shell for [Brackets](https://github.com/adobe/brackets). 


### PR DESCRIPTION
* Remove vscode recommendation. 
* Brackets is under active dev and we don't recommend moving to vscode.